### PR TITLE
feat(pi): Add custom Gondolin VM image with git, ripgrep, jq, fd

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,8 +61,9 @@ pi/
 │       │   ├── answer.ts       # User-initiated Q&A extraction
 │       │   ├── exit.ts         # Graceful terminal exit
 │       │   └── gondolin.ts     # Gondolin VM sandboxing
+│       ├── gondolin-image.json # Custom VM image build config (git, ripgrep, etc.)
 │       ├── package.json        # Extension dependencies
-│       ├── settings.json       # pi global settings
+│       ├── settings.json        # pi global settings
 │       └── themes/
 │           └── catppuccin-mocha.json
 └── README.md
@@ -104,9 +105,7 @@ user to run on their host** after making changes:
 # Deploy config changes (symlink into ~/.pi/agent)
 cd ~/code/github.com/hrmnjt/dev   # adjust path as needed
 stow -t ~ pi
-
-# Install/update extension dependencies
-cd ~/.pi/agent && npm install
+just pi-deps
 ```
 
 Then tell the user to type `/reload` in pi to hot-reload extensions.
@@ -135,3 +134,23 @@ Usage: `/exit`
 ### gondolin
 Sandboxes all tool operations inside a lightweight VM. Mounts workspace and
 pi docs/examples. This is the extension you're currently inside.
+
+**Custom VM image:** The default Alpine VM lacks git and other dev tools.
+A custom image with pre-installed packages is configured via
+`pi/.pi/agent/gondolin-image.json`. Build it once:
+
+```bash
+# One-time build (on host Mac)
+npx @earendil-works/gondolin build \
+  --config pi/.pi/agent/gondolin-image.json \
+  --output ~/.gondolin/custom-image
+```
+
+Then set the env var before starting pi (or add to your shell profile):
+
+```bash
+export GONDOLIN_GUEST_DIR="$HOME/.gondolin/custom-image"
+```
+
+To add more tools, edit `gondolin-image.json` → `rootfsPackages`, rebuild,
+and restart pi. The build output (~200MB) is stored outside the repo.

--- a/Brewfile
+++ b/Brewfile
@@ -29,6 +29,8 @@ brew "luarocks"                 # Lua package manager
 brew "hugo"                     # Blog SSG
 brew "duckdb"
 brew "qemu"                     # Virtualization for Gondolin sandbox
+brew "lz4"                      # Compression for Gondolin custom image builds
+brew "e2fsprogs"                # ext4 tools for Gondolin custom image builds
 brew "sinelaw/fresh/fresh-editor" # another terminal editor that I'm trying
 
 # Media

--- a/Justfile
+++ b/Justfile
@@ -47,3 +47,18 @@ xdgsetup:
 # Generate ed25519 SSH key for GitHub, add to ssh-agent, copy pubkey to clipboard
 ghsshkey:
     ./_scripts/sshsetup.sh
+
+# --- Gondolin VM image ---
+
+# Build a custom VM image with git, ripgrep, jq, fd, and other dev tools.
+# Config: pi/.pi/agent/gondolin-image.json
+# Output: ~/.gondolin/custom-image (used by GONDOLIN_GUEST_DIR env var)
+# Requires: lz4, e2fsprogs (see Brewfile)
+gondolin-image:
+    npx @earendil-works/gondolin build \
+        --config pi/.pi/agent/gondolin-image.json \
+        --output ~/.gondolin/custom-image
+
+# Install pi extension dependencies (run after stowall)
+pi-deps:
+    npm install --prefix ~/.pi/agent

--- a/README.md
+++ b/README.md
@@ -38,10 +38,13 @@ just brewinst
 # Step 6: .dotfiles in place with stow
 `just stowall`
 
-# Step 7: Generate SSH key for GitHub
+# Step 7: Install pi extension dependencies
+`just pi-deps`
+
+# Step 8: Generate SSH key for GitHub
 `just ghsshkey`
 
-# Step 8: Create git directory structure
+# Step 9: Create git directory structure
 `just gitsetup`
 ```
 

--- a/pi/.pi/agent/extensions/gondolin.ts
+++ b/pi/.pi/agent/extensions/gondolin.ts
@@ -261,10 +261,16 @@ export default function (pi: ExtensionAPI) {
         mounts[GUEST_PI_EXAMPLES] = new RealFSProvider(piResources.examples);
       }
 
+      // Support custom VM images (e.g. with git pre-installed).
+      // Set GONDOLIN_GUEST_DIR to the output of `just gondolin-image`.
+      // Falls back to the default alpine-base image if unset.
+      const imagePath = process.env.GONDOLIN_GUEST_DIR || undefined;
+
       const created = await VM.create({
         vfs: {
           mounts,
         },
+        ...(imagePath ? { sandbox: { imagePath } } : {}),
       });
 
       vm = created;

--- a/pi/.pi/agent/gondolin-image.json
+++ b/pi/.pi/agent/gondolin-image.json
@@ -1,0 +1,25 @@
+{
+  "arch": "aarch64",
+  "distro": "alpine",
+  "alpine": {
+    "version": "3.23.0",
+    "kernelPackage": "linux-virt",
+    "kernelImage": "vmlinuz-virt",
+    "rootfsPackages": [
+      "linux-virt",
+      "rng-tools",
+      "bash",
+      "ca-certificates",
+      "curl",
+      "nodejs",
+      "npm",
+      "uv",
+      "python3",
+      "openssh",
+      "git",
+      "ripgrep",
+      "jq",
+      "fd"
+    ]
+  }
+}

--- a/pi/README.md
+++ b/pi/README.md
@@ -12,6 +12,7 @@ pi/
 │       │   ├── answer.ts       # User-initiated Q&A extraction
 │       │   ├── exit.ts         # Graceful terminal exit
 │       │   └── gondolin.ts     # Gondolin VM sandboxing
+│       ├── gondolin-image.json # Custom VM image build config
 │       ├── package.json        # Extension dependencies
 │       ├── settings.template.json   # Intentional settings (tracked)
 │       ├── settings.json       # Runtime settings (gitignored)
@@ -26,8 +27,7 @@ pi/
 # From repo root
 stow -t ~ pi
 
-# Install extension dependencies
-cd ~/.pi/agent && npm install
+just pi-deps
 
 # Install QEMU (fallback backend for Gondolin)
 brew install qemu   # macOS
@@ -131,6 +131,36 @@ Linux micro-VM. Based on the [official example](https://github.com/earendil-work
 - Redirects all file and shell tool operations into the sandbox
 - Runs user `!` commands inside the VM too
 - Patches the system prompt so the model sees `/workspace` paths
+
+**Custom VM image:**
+
+The default Alpine VM image lacks `git` and other dev tools. A custom image
+with pre-installed packages is configured in `gondolin-image.json`.
+
+```bash
+# One-time build (requires lz4 and e2fsprogs from Brewfile)
+just gondolin-image
+```
+
+This produces `~/.gondolin/custom-image/` (~200MB), pointed to by the
+`GONDOLIN_GUEST_DIR` env var. The extension reads this var and passes it
+to `VM.create()` — falling back to the default Alpine image if unset.
+
+```bash
+# Add to ~/.zshrc for persistence
+export GONDOLIN_GUEST_DIR="$HOME/.gondolin/custom-image"
+```
+
+**Adding tools to the VM:**
+
+Edit `gondolin-image.json` → `rootfsPackages`, add Alpine package names,
+then rebuild:
+
+```bash
+just gondolin-image
+```
+
+Restart pi to use the new image. No extension changes needed.
 
 **Performance on Apple Silicon:**
 

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -6,6 +6,9 @@
 eval "$(/opt/homebrew/bin/brew shellenv)"
 export HOMEBREW_NO_AUTO_UPDATE=1
 
+# Gondolin custom VM image (built with `just gondolin-image`)
+export GONDOLIN_GUEST_DIR="$HOME/.gondolin/custom-image"
+
 # direnv
 eval "$(direnv hook zsh)"
 


### PR DESCRIPTION
- pi/.pi/agent/gondolin-image.json: build config with pre-installed dev tools
- pi/.pi/agent/extensions/gondolin.ts: read GONDOLIN_GUEST_DIR for custom image
- zsh/.zshrc: export GONDOLIN_GUEST_DIR
- Brewfile: add lz4, e2fsprogs (gondolin build deps)
- Justfile: add gondolin-image and pi-deps recipes
- README.md, pi/README.md, AGENTS.md: updated docs