### PR TITLE
feat: add cmux sidebar progress status and tune notification settings

### DIFF
--- a/cmux/.config/cmux/cmux.json
+++ b/cmux/.config/cmux/cmux.json
@@ -14,7 +14,8 @@
     "newWorkspacePlacement": "afterCurrent",
     "minimalMode": false,
     "focusPaneOnFirstClick": true,
-    "confirmQuit": true
+    "confirmQuit": true,
+    "reorderOnNotification": false
   },
 
   "terminal": {
@@ -24,7 +25,8 @@
   },
 
   "notifications": {
-    "unreadPaneRing": true,
+    "unreadPaneRing": false,
+    "paneFlash": false,
     "dockBadge": true,
     "sound": "default"
   },
@@ -40,7 +42,6 @@
   },
 
   "workspaceColors": {
-    "selectionColor": "#504945",
     "notificationBadgeColor": "#FE8019",
     "colors": {
       "Red": "#CC241D",

--- a/pi/.pi/agent/extensions/cmux-session.ts
+++ b/pi/.pi/agent/extensions/cmux-session.ts
@@ -1,0 +1,155 @@
+// cmux-pi-session-extension-marker v1
+// Bridges Pi session lifecycle events into cmux's restorable session store.
+// Installed by `cmux hooks pi install` or `cmux hooks setup`.
+// DO NOT EDIT MANUALLY. cmux upgrades this file in place.
+
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { AgentEndEvent, ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+
+function firstString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) return value.trim();
+  }
+  return null;
+}
+
+function resolveExecutable(name: string): string {
+  const pathEnv = process.env.PATH || "";
+  for (const dir of pathEnv.split(path.delimiter)) {
+    if (!dir) continue;
+    const candidate = path.join(dir, name);
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      return candidate;
+    } catch (_) {}
+  }
+  return name;
+}
+
+function looksLikePiExecutable(value: string): boolean {
+  const base = path.basename(value).toLowerCase();
+  return base === "pi" || base === "pi-coding-agent";
+}
+
+function looksLikePiScript(value: string): boolean {
+  const normalized = value.replaceAll("\\", "/");
+  const base = path.basename(normalized).toLowerCase();
+  return (
+    normalized.includes("/@mariozechner/pi-coding-agent/") ||
+    normalized.includes("/packages/coding-agent/") ||
+    (base === "cli.js" && normalized.includes("pi-coding-agent")) ||
+    (base === "cli.ts" && normalized.includes("coding-agent"))
+  );
+}
+
+function normalizedLaunchArgv(): string[] {
+  const raw = Array.isArray(process.argv) ? process.argv.map((value) => String(value)) : [];
+  if (raw.length === 0) return [resolveExecutable("pi")];
+  if (looksLikePiExecutable(raw[0])) return raw;
+  if (raw.length > 1 && looksLikePiScript(raw[1])) {
+    return [resolveExecutable("pi"), ...raw.slice(2)];
+  }
+  return [resolveExecutable("pi"), ...raw.slice(1)];
+}
+
+function base64NulSeparated(values: string[]): string {
+  const bytes: Buffer[] = [];
+  for (const value of values) {
+    bytes.push(Buffer.from(String(value), "utf8"));
+    bytes.push(Buffer.from([0]));
+  }
+  return Buffer.concat(bytes).toString("base64");
+}
+
+function hookEnvironment(cwd: string): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  delete env.AMP_API_KEY;
+  if (!env.CMUX_AGENT_LAUNCH_ARGV_B64) {
+    const argv = normalizedLaunchArgv();
+    env.CMUX_AGENT_LAUNCH_KIND = "pi";
+    env.CMUX_AGENT_LAUNCH_EXECUTABLE = argv[0] || resolveExecutable("pi");
+    env.CMUX_AGENT_LAUNCH_ARGV_B64 = base64NulSeparated(argv);
+    env.CMUX_AGENT_LAUNCH_CWD = cwd || process.cwd();
+  }
+  return env;
+}
+
+function eventName(subcommand: string): string {
+  switch (subcommand) {
+    case "session-start":
+      return "SessionStart";
+    case "prompt-submit":
+      return "UserPromptSubmit";
+    case "stop":
+      return "Stop";
+    default:
+      return subcommand;
+  }
+}
+
+function textFromContent(content: unknown): string | null {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return null;
+  const parts: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    const typed = block as { type?: unknown; text?: unknown };
+    if (typed.type === "text" && typeof typed.text === "string") parts.push(typed.text);
+  }
+  return parts.join("\n") || null;
+}
+
+function lastAssistantMessage(event: AgentEndEvent): string | undefined {
+  for (let index = event.messages.length - 1; index >= 0; index -= 1) {
+    const message = event.messages[index];
+    if (!message || typeof message !== "object") continue;
+    const typed = message as { role?: unknown; content?: unknown };
+    if (typed.role !== "assistant") continue;
+    const text = firstString(textFromContent(typed.content));
+    if (text) return text;
+  }
+  return undefined;
+}
+
+function sendHook(subcommand: string, ctx: ExtensionContext, extra: Record<string, unknown> = {}): void {
+  if (process.env.CMUX_PI_HOOKS_DISABLED === "1") return;
+  if (!process.env.CMUX_SURFACE_ID) return;
+
+  const sessionId = firstString(ctx.sessionManager.getSessionId());
+  if (!sessionId) return;
+
+  const cwd = firstString(ctx.cwd, process.cwd()) || process.cwd();
+  const payload: Record<string, unknown> = {
+    session_id: sessionId,
+    cwd,
+    hook_event_name: eventName(subcommand),
+    event: eventName(subcommand),
+    ...extra,
+  };
+  const cmux = process.env.CMUX_PI_CMUX_BIN || "cmux";
+  try {
+    spawnSync(cmux, ["hooks", "pi", subcommand], {
+      input: JSON.stringify(payload),
+      encoding: "utf8",
+      env: hookEnvironment(cwd),
+      stdio: ["pipe", "ignore", "ignore"],
+      timeout: 5000,
+    });
+  } catch (_) {}
+}
+
+export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
+  pi.on("session_start", async (_event, ctx) => {
+    sendHook("session-start", ctx);
+  });
+
+  pi.on("before_agent_start", async (event, ctx) => {
+    sendHook("prompt-submit", ctx, { prompt: event.prompt });
+  });
+
+  pi.on("agent_end", async (event, ctx) => {
+    sendHook("stop", ctx, { last_assistant_message: lastAssistantMessage(event) });
+  });
+}

--- a/pi/.pi/agent/extensions/notify.ts
+++ b/pi/.pi/agent/extensions/notify.ts
@@ -156,6 +156,30 @@ function formatNotification(
   };
 }
 
+function cmuxSetStatus(value: string): void {
+  // Update cmux sidebar progress indicator via the cmux CLI.
+  // No-op when not running inside cmux (no CMUX_SOCKET_PATH).
+  if (!process.env.CMUX_SOCKET_PATH) return;
+  try {
+    spawnSync("cmux", ["set-status", "pi", value], {
+      encoding: "utf8",
+      stdio: ["ignore", "ignore", "ignore"],
+      timeout: 3000,
+    });
+  } catch (_) {}
+}
+
+function cmuxClearStatus(): void {
+  if (!process.env.CMUX_SOCKET_PATH) return;
+  try {
+    spawnSync("cmux", ["clear-status", "pi"], {
+      encoding: "utf8",
+      stdio: ["ignore", "ignore", "ignore"],
+      timeout: 3000,
+    });
+  } catch (_) {}
+}
+
 function notifyOSC777(title: string, body: string): void {
   // Ghostty, iTerm2, rxvt-unicode: ESC ] 777 ; notify ; title ; body BEL
   process.stdout.write(`\x1b]777;notify;${sanitizeOSCField(title)};${sanitizeOSCField(body)}\x07`);
@@ -165,13 +189,28 @@ export default function (pi: ExtensionAPI) {
   let enabled = envFlag("PI_NOTIFY", true);
   const sessionLabel = getSessionLabel();
 
+  pi.on("before_agent_start", async (_event, _ctx) => {
+    cmuxSetStatus("Running");
+  });
+
   pi.on("agent_end", async (event, ctx) => {
+    // Always update sidebar status regardless of notification toggle
+    if (ctx.hasPendingMessages()) {
+      cmuxSetStatus("Waiting");
+    } else {
+      cmuxSetStatus("Idle");
+    }
+
     if (!enabled) return;
     if (ctx.hasPendingMessages()) return;
 
     const text = extractLastAssistantText((event.messages ?? []) as MessageLike[]);
     const { title, body } = formatNotification(text, sessionLabel);
     notifyOSC777(title, body);
+  });
+
+  pi.on("session_shutdown", async (_event, _ctx) => {
+    cmuxClearStatus();
   });
 
   pi.registerCommand("notify", {


### PR DESCRIPTION
- Add cmux set-status/clear-status calls to notify.ts extension:
  - Running on before_agent_start
  - Waiting on agent_end with pending messages
  - Idle on agent_end without pending messages
  - Clear on session_shutdown
- Track cmux-session.ts hook installed by
- Disable reorderOnNotification to keep workspace positions stable
- Disable unreadPaneRing and paneFlash to stop intrusive blue ring
- Remove selectionColor override to improve indicator visibility